### PR TITLE
Don't call self.inner.read() with empty buffer

### DIFF
--- a/src/newc.rs
+++ b/src/newc.rs
@@ -216,9 +216,13 @@ impl<R: Read> Read for Reader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let remaining = self.entry.file_size - self.bytes_read;
         let limit = buf.len().min(remaining as usize);
-        let num_bytes = try!(self.inner.read(&mut buf[..limit]));
-        self.bytes_read += num_bytes as u32;
-        Ok(num_bytes)
+        if limit > 0 {
+            let num_bytes = try!(self.inner.read(&mut buf[..limit]));
+            self.bytes_read += num_bytes as u32;
+            Ok(num_bytes)
+        } else {
+            Ok(0)
+        }
     }
 }
 


### PR DESCRIPTION
Alas, I have just learned the hard way that some `Read` implementations (in this case, `flate2::read::GzEncoder`) don't behave nicely when `read()` is called with an empty buffer (you'd think they'd just return `Ok(0)`, but `GzEncoder` [gets confused](https://github.com/alexcrichton/flate2-rs/pull/150)).  However, the `Read` implementation for `newc::Reader` calls `self.inner.read()` with a buffer limited in length to the size of the remaining data, which could be zero even if the original buffer was nonempty.  (And so I had a bug where copying data from an entry in a gzipped cpio archive would fail.)

This PR adds the simple workaround of not bothering to call `self.inner.read()` if `limit` is zero.  I think this is probably slightly better anyway, even for better-behaved inner readers, since `self.inner.read()` could potentially involve a syscall or some other relatively expensive operation, and there's no reason to do that if we already know we won't be returning any data.