### PR TITLE
Trim trailing NUL bytes from filename when reading

### DIFF
--- a/src/newc.rs
+++ b/src/newc.rs
@@ -191,6 +191,11 @@ impl<R: Read> Reader<R> {
             ));
         }
         name_bytes.pop();
+        // dracut-cpio sometimes pads the name to the next filesystem block.
+        // See https://github.com/dracutdevs/dracut/commit/a9c67046
+        while name_bytes.last() == Some(&0) {
+            name_bytes.pop();
+        }
         let name = String::from_utf8(name_bytes).map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, "Entry name was not valid UTF-8")
         })?;


### PR DESCRIPTION
[dracut-cpio](https://github.com/dracutdevs/dracut/blob/master/src/dracut-cpio/src/main.rs) [intentionally](https://github.com/dracutdevs/dracut/blob/fe8df0240a24b9d2d60a5b0b998f82b251ede849/src/dracut-cpio/src/main.rs#L401-L406) creates archives that can have extra NUL bytes at the end of a filename.  Truncate those off when reading.