### PR TITLE
adding a `Reader::to_writer` helper to take advantage of platform-specific file copy behavior

### DIFF
--- a/examples/extractcpio.rs
+++ b/examples/extractcpio.rs
@@ -1,0 +1,29 @@
+// Extract a file from a CPIO archive.
+
+extern crate cpio;
+
+fn main() {
+    let path = std::env::args().nth(1).unwrap();
+    let filename = std::env::args().nth(2).unwrap();
+    let output = std::env::args().nth(3).unwrap();
+    let mut file = std::fs::File::open(path).unwrap();
+    loop {
+        let reader = cpio::NewcReader::new(file).unwrap();
+        if reader.entry().is_trailer() {
+            break;
+        }
+
+        if filename == reader.entry().name() {
+            println!(
+                "{} ({} bytes)",
+                reader.entry().name(),
+                reader.entry().file_size()
+            );
+
+            let out = std::fs::File::create(&output).unwrap();
+            file = reader.to_writer(out).unwrap();
+        } else {
+            file = reader.skip().unwrap();
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,22 +21,20 @@ where
 {
     let output = inputs
         .enumerate()
-        .fold(Ok(output), |output, (idx, (builder, mut input))| {
+        .try_fold(output, |output, (idx, (builder, mut input))| {
             // If the output is valid, try to write the next input file
-            output.and_then(move |output| {
-                // Grab the length of the input file
-                let len = input.seek(io::SeekFrom::End(0))?;
-                input.seek(io::SeekFrom::Start(0))?;
+            // Grab the length of the input file
+            let len = input.seek(io::SeekFrom::End(0))?;
+            input.seek(io::SeekFrom::Start(0))?;
 
-                // Create our writer fp with a unique inode number
-                let mut fp = builder.ino(idx as u32).write(output, len as u32);
+            // Create our writer fp with a unique inode number
+            let mut fp = builder.ino(idx as u32).write(output, len as u32);
 
-                // Write out the file
-                io::copy(&mut input, &mut fp)?;
+            // Write out the file
+            io::copy(&mut input, &mut fp)?;
 
-                // And finish off the input file
-                fp.finish()
-            })
+            // And finish off the input file
+            fp.finish()
         })?;
 
     newc::trailer(output)

--- a/src/newc.rs
+++ b/src/newc.rs
@@ -409,9 +409,9 @@ impl Builder {
         Writer {
             inner: w,
             written: 0,
-            file_size: file_size,
+            file_size,
             header_size: header.len(),
-            header: header,
+            header,
         }
     }
 
@@ -468,7 +468,7 @@ impl<W: Write> Writer<W> {
     }
 
     fn try_write_header(&mut self) -> io::Result<()> {
-        if self.header.len() != 0 {
+        if !self.header.is_empty() {
             self.inner.write_all(&self.header)?;
             self.header.truncate(0);
         }
@@ -480,7 +480,7 @@ impl<W: Write> Writer<W> {
 
         if self.written == self.file_size {
             if let Some(pad) = pad(self.header_size + self.file_size as usize) {
-                self.inner.write(&pad)?;
+                self.inner.write_all(&pad)?;
                 self.inner.flush()?;
             }
         }


### PR DESCRIPTION
On Linux, if the `Read` and the `Write` passed to `std::io::copy` are both files, `std::io::copy` has a platform-specific optimization to use `copy_file_range`. With our `Read` implementation, the `Reader` struct could not take advantage of this to accelerate copying data out of the archive. However, by providing a `Reader::to_writer` implementation, we can use `std::io::copy` behind the scenes to get that acceleration back if the source and destinations are both actual files on the filesystem.

This also provides `offset` and `skip` methods if the inner handle implements `Seek`. This can be used as a fallback if the platform-specific behavior changes in the future.

Finally, this fixes up a few clippy lints that have accumulated.